### PR TITLE
Fix aplite build error

### DIFF
--- a/src/pge/universal_fb/universal_fb.c
+++ b/src/pge/universal_fb/universal_fb.c
@@ -56,7 +56,7 @@ void universal_fb_set_pixel_color(GBitmapDataRowInfo info, GRect bounds, GPoint 
 #elif defined(PBL_BW)
     uint8_t byte = point.x / 8;
     uint8_t bit = point.x % 8; // fb: bwbb bbbb -> byte: 0000 0010
-    byte_set_bit(&info.data[byte], bit, color);
+    byte_set_bit(&info.data[byte], bit, color.argb);
 #endif
   } else {
     // Out of bounds


### PR DESCRIPTION
I think the error is due to the discrepancy in the underlying data type of `GColor` between the 2.x aplite SDK and the new 3.8 aplite SDK (for which I'm experiencing a build error). This fix might not be the best if you still want to support the 2.x aplite SDK.
